### PR TITLE
Add uncensored llm option

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,14 +1,12 @@
-from .hidreamsampler import HiDreamSampler
+from .hidreamsampler import HiDreamSampler, HiDreamSamplerAdvanced
 
 NODE_CLASS_MAPPINGS = {
     "HiDreamSampler": HiDreamSampler,
     "HiDreamSamplerAdvanced": HiDreamSamplerAdvanced
 }
-
 NODE_DISPLAY_NAME_MAPPINGS = {
     "HiDreamSampler": "HiDream Sampler",
     "HiDreamSamplerAdvanced": "HiDream Sampler (Advanced)"
 }
-
 WEB_DIRECTORY = "./web"
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,13 @@
 from .hidreamsampler import HiDreamSampler
 
 NODE_CLASS_MAPPINGS = {
-    "HiDreamSampler": HiDreamSampler
+    "HiDreamSampler": HiDreamSampler,
+    "HiDreamSamplerAdvanced": HiDreamSamplerAdvanced
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "HiDreamSampler": "HiDream Sampler"
+    "HiDreamSampler": "HiDream Sampler",
+    "HiDreamSamplerAdvanced": "HiDream Sampler (Advanced)"
 }
 
 WEB_DIRECTORY = "./web"

--- a/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py
+++ b/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py
@@ -537,6 +537,10 @@ class HiDreamImagePipeline(DiffusionPipeline, FromSingleFileMixin):
         callback_on_step_end: Optional[Callable[[int, int, Dict], None]] = None,
         callback_on_step_end_tensor_inputs: List[str] = ["latents"],
         max_sequence_length: int = 128,
+        max_sequence_length_clip_l: Optional[int] = None,
+        max_sequence_length_openclip: Optional[int] = None,
+        max_sequence_length_t5: Optional[int] = None,
+        max_sequence_length_llama: Optional[int] = None,
     ):
         height = height or self.default_sample_size * self.vae_scale_factor
         width = width or self.default_sample_size * self.vae_scale_factor

--- a/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py
+++ b/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py
@@ -216,13 +216,6 @@ class HiDreamImagePipeline(DiffusionPipeline, FromSingleFileMixin):
         )
 
         text_input_ids = text_inputs.input_ids
-        untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
-        if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(text_input_ids, untruncated_ids):
-            removed_text = tokenizer.batch_decode(untruncated_ids[:, 218 - 1 : -1])
-            logger.warning(
-                "The following part of your input was truncated because CLIP can only handle sequences up to"
-                f" {218} tokens: {removed_text}"
-            )
         prompt_embeds = text_encoder(text_input_ids.to(device), output_hidden_states=True)
 
         # Use pooled output of CLIPTextModel

--- a/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py
+++ b/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py
@@ -558,14 +558,18 @@ class HiDreamImagePipeline(DiffusionPipeline, FromSingleFileMixin):
         max_sequence_length_t5: Optional[int] = None,
         max_sequence_length_llama: Optional[int] = None,
     ):
+        disable scaling entirely
         height = height or self.default_sample_size * self.vae_scale_factor
         width = width or self.default_sample_size * self.vae_scale_factor
-
         division = self.vae_scale_factor * 2
-        S_max = (self.default_sample_size * self.vae_scale_factor) ** 2
-        scale = S_max / (width * height)
-        scale = math.sqrt(scale)
-        width, height = int(width * scale // division * division), int(height * scale // division * division)
+        
+        # Force dimensions to be divisible by division without any area scaling
+        width = int(width // division * division)
+        height = int(height // division * division)
+        
+        # Ensure minimum dimensions
+        width = max(width, division)
+        height = max(height, division)
 
         self._guidance_scale = guidance_scale
         self._joint_attention_kwargs = joint_attention_kwargs

--- a/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py
+++ b/hi_diffusers/pipelines/hidream_image/pipeline_hidream_image.py
@@ -558,7 +558,7 @@ class HiDreamImagePipeline(DiffusionPipeline, FromSingleFileMixin):
         max_sequence_length_t5: Optional[int] = None,
         max_sequence_length_llama: Optional[int] = None,
     ):
-        disable scaling entirely
+        # disable scaling entirely
         height = height or self.default_sample_size * self.vae_scale_factor
         width = width or self.default_sample_size * self.vae_scale_factor
         division = self.vae_scale_factor * 2

--- a/hidreamsampler.py
+++ b/hidreamsampler.py
@@ -223,67 +223,77 @@ def load_models(model_type, use_uncensored_llm=False):
             llama_model_name = UNCENSORED_NF4_LLAMA_MODEL_NAME
             print(f"\n[1a] Preparing UNCENSORED LLM for NF4: {llama_model_name}")
             
-            if accelerate_available and optimum_available and autogptq_available:
-                # Special handling for loading uncensored model with GPTQ
+            # Try multiple approaches for uncensored model with NF4
+            try:
+                # First try: Use optimum.gptq if available
+                if optimum_available and autogptq_available:
+                    try:
+                        # Check if GPTQConfig is available (newer versions of optimum)
+                        import optimum.gptq
+                        if hasattr(optimum.gptq, 'GPTQConfig'):
+                            from optimum.gptq import GPTQConfig
+                            print("     Using optimum.gptq.GPTQConfig")
+                            gptq_config = GPTQConfig(bits=4, group_size=128, desc_act=True)
+                            text_encoder_load_kwargs["quantization_config"] = gptq_config
+                        else:
+                            raise ImportError("GPTQConfig not found in optimum.gptq")
+                    except ImportError as e:
+                        print(f"     GPTQ quantization not available: {e}")
+                        raise
+                else:
+                    raise ImportError("optimum or auto_gptq not available")
+                        
+            except Exception as e1:
+                print(f"     GPTQ approach failed: {e1}")
+                
+                # Second try: Use BitsAndBytes (BNB) for 4-bit quantization
                 try:
-                    from optimum.gptq import GPTQConfig
-                    
-                    print("     Loading with GPTQ quantization for uncensored model")
-                    gptq_config = GPTQConfig(bits=4, group_size=128, desc_act=True)
-                    
-                    # Load in bfloat16 first then quantize
-                    print("     Setting up quantization parameters...")
-                    text_encoder_load_kwargs.pop("quantization_config", None)  # Remove BNB config if present
-                    text_encoder_load_kwargs["quantization_config"] = gptq_config
-                    text_encoder_load_kwargs["device_map"] = "auto"
-                    
-                    # Limit memory usage
-                    if hasattr(torch.cuda, 'get_device_properties') and torch.cuda.is_available():
-                        total_mem = torch.cuda.get_device_properties(0).total_memory / (1024**3)
-                        max_mem = int(total_mem * 0.4)
-                        text_encoder_load_kwargs["max_memory"] = {0: f"{max_mem}GiB"}
-                        print(f"     Setting max memory limit: {max_mem}GiB of {total_mem:.1f}GiB")
-                except Exception as e:
-                    print(f"     Error setting up GPTQ quantization: {e}")
-                    print("     Falling back to standard model instead")
+                    if bnb_available:
+                        print("     Falling back to BitsAndBytes 4-bit quantization")
+                        # Create a special BNB config for the uncensored model
+                        from transformers import BitsAndBytesConfig
+                        uncensored_bnb_config = BitsAndBytesConfig(
+                            load_in_4bit=True,
+                            bnb_4bit_compute_dtype=torch.bfloat16,
+                            bnb_4bit_quant_type="nf4"
+                        )
+                        text_encoder_load_kwargs["quantization_config"] = uncensored_bnb_config
+                        # Don't use device_map with BNB
+                        text_encoder_load_kwargs.pop("device_map", None)
+                    else:
+                        raise ImportError("BitsAndBytes not available")
+                except Exception as e2:
+                    print(f"     BNB fallback also failed: {e2}")
+                    print("     ⚠️ Using standard (censored) model instead")
                     llama_model_name = NF4_LLAMA_MODEL_NAME
-            else:
-                print("     ⚠️ Warning: Missing dependencies for GPTQ quantization")
-                print("     Falling back to standard model instead")
-                llama_model_name = NF4_LLAMA_MODEL_NAME
+                    # Reset to default GPTQ setup
+                    text_encoder_load_kwargs.pop("quantization_config", None)
+                    if accelerate_available:
+                        text_encoder_load_kwargs["device_map"] = "auto"
+            
+            # Set device map and memory limits for either approach
+            if "device_map" in text_encoder_load_kwargs and accelerate_available:
+                # Set memory limits if using device_map
+                if hasattr(torch.cuda, 'get_device_properties') and torch.cuda.is_available():
+                    total_mem = torch.cuda.get_device_properties(0).total_memory / (1024**3)
+                    max_mem = int(total_mem * 0.4)
+                    text_encoder_load_kwargs["max_memory"] = {0: f"{max_mem}GiB"}
+                    print(f"     Setting max memory limit: {max_mem}GiB of {total_mem:.1f}GiB")
         else:
+            # Original handling for standard NF4 models
             llama_model_name = NF4_LLAMA_MODEL_NAME
             print(f"\n[1a] Preparing LLM (GPTQ): {llama_model_name}")
-            
-        if accelerate_available:
-            # Configure device map for auto placement
-            if "device_map" not in text_encoder_load_kwargs:
+            if accelerate_available:
                 text_encoder_load_kwargs["device_map"] = "auto"
+                # Set memory limits if using device_map
+                if hasattr(torch.cuda, 'get_device_properties') and torch.cuda.is_available():
+                    total_mem = torch.cuda.get_device_properties(0).total_memory / (1024**3)
+                    max_mem = int(total_mem * 0.4)
+                    text_encoder_load_kwargs["max_memory"] = {0: f"{max_mem}GiB"}
+                    print(f"     Setting max memory limit: {max_mem}GiB of {total_mem:.1f}GiB")
                 print("     Using device_map='auto'")
-            
-            # Set memory limits if not already set
-            if "max_memory" not in text_encoder_load_kwargs and \
-               hasattr(torch.cuda, 'get_device_properties') and torch.cuda.is_available():
-                total_mem = torch.cuda.get_device_properties(0).total_memory / (1024**3)
-                max_mem = int(total_mem * 0.4)
-                text_encoder_load_kwargs["max_memory"] = {0: f"{max_mem}GiB"}
-                print(f"     Setting max memory limit: {max_mem}GiB of {total_mem:.1f}GiB")
-        else:
-            print("     accelerate not found, attempting manual placement")
-    else:
-        # Standard models can use the uncensored version directly
-        if use_uncensored_llm:
-            llama_model_name = UNCENSORED_LLAMA_MODEL_NAME
-            print(f"\n[1a] Preparing UNCENSORED LLM (4-bit BNB): {llama_model_name}")
-        else:
-            llama_model_name = ORIGINAL_LLAMA_MODEL_NAME
-            print(f"\n[1a] Preparing LLM (4-bit BNB): {llama_model_name}")
-            
-        if bnb_llm_config:
-            text_encoder_load_kwargs["quantization_config"] = bnb_llm_config
-            print("     Using 4-bit BNB")
-        else:
-            raise ImportError("BNB config required for standard LLM")
+            else:
+                print("     accelerate not found, attempting manual placement")
         
         text_encoder_load_kwargs["attn_implementation"] = "flash_attention_2" if hasattr(torch.nn.functional, 'scaled_dot_product_attention') else "eager"
     

--- a/hidreamsampler.py
+++ b/hidreamsampler.py
@@ -341,7 +341,7 @@ class HiDreamSampler:
         print("HiDream: Cache cleared")
         return True
         
-    @classmethod@classmethod
+    @classmethod
     def INPUT_TYPES(s):
         available_model_types = list(MODEL_CONFIGS.keys())
         if not available_model_types:

--- a/hidreamsampler.py
+++ b/hidreamsampler.py
@@ -223,24 +223,15 @@ def load_models(model_type, use_uncensored_llm=False):
             llama_model_name = UNCENSORED_NF4_LLAMA_MODEL_NAME
             print(f"\n[1a] Preparing UNCENSORED LLM for NF4: {llama_model_name}")
             
-            # Much simpler approach - load in float16 without quantization
-            print("     Loading uncensored model in float16 (no quantization)")
-            # Clear out any quantization configs
+            # Simple approach - load to single device without device mapping
+            print("     Loading uncensored model in float16 directly to CUDA")
             text_encoder_load_kwargs.pop("quantization_config", None)
-            # Use float16 instead of bfloat16 for better compatibility
+            text_encoder_load_kwargs.pop("device_map", None)  # Remove any device mapping
+            text_encoder_load_kwargs.pop("max_memory", None)  # Remove memory constraints
             text_encoder_load_kwargs["torch_dtype"] = torch.float16
             
-            if accelerate_available:
-                # Use accelerate for device mapping
-                text_encoder_load_kwargs["device_map"] = "auto"
-                # Set memory limits to avoid OOM
-                if hasattr(torch.cuda, 'get_device_properties') and torch.cuda.is_available():
-                    total_mem = torch.cuda.get_device_properties(0).total_memory / (1024**3)
-                    max_mem = int(total_mem * 0.4)
-                    text_encoder_load_kwargs["max_memory"] = {0: f"{max_mem}GiB"}
-                    print(f"     Setting max memory limit: {max_mem}GiB of {total_mem:.1f}GiB")
-            else:
-                print("     accelerate not found, will load to CPU first")
+            # Don't use accelerate's device_map for uncensored
+            use_cuda_directly = True
         else:
             # Original handling for standard NF4 models
             llama_model_name = NF4_LLAMA_MODEL_NAME
@@ -254,8 +245,10 @@ def load_models(model_type, use_uncensored_llm=False):
                     text_encoder_load_kwargs["max_memory"] = {0: f"{max_mem}GiB"}
                     print(f"     Setting max memory limit: {max_mem}GiB of {total_mem:.1f}GiB")
                 print("     Using device_map='auto'")
+                use_cuda_directly = False
             else:
                 print("     accelerate not found, attempting manual placement")
+                use_cuda_directly = True
     else:
         # Standard models can use the uncensored version directly
         if use_uncensored_llm:
@@ -272,6 +265,7 @@ def load_models(model_type, use_uncensored_llm=False):
             raise ImportError("BNB config required for standard LLM")
         
         text_encoder_load_kwargs["attn_implementation"] = "flash_attention_2" if hasattr(torch.nn.functional, 'scaled_dot_product_attention') else "eager"
+        use_cuda_directly = True
     
     print(f"[1b] Loading Tokenizer: {llama_model_name}...")
     tokenizer = AutoTokenizer.from_pretrained(llama_model_name, use_fast=False)
@@ -279,7 +273,8 @@ def load_models(model_type, use_uncensored_llm=False):
     
     print(f"[1c] Loading Text Encoder: {llama_model_name}... (May download files)")
     text_encoder = LlamaForCausalLM.from_pretrained(llama_model_name, **text_encoder_load_kwargs)
-    if "device_map" not in text_encoder_load_kwargs: 
+    
+    if use_cuda_directly and "device_map" not in text_encoder_load_kwargs: 
         print("     Moving text encoder to CUDA...")
         text_encoder.to("cuda")
     
@@ -287,75 +282,44 @@ def load_models(model_type, use_uncensored_llm=False):
     print(f"✅ Text encoder loaded! (VRAM: {step1_mem:.2f} MB)")
     
     # --- 2. Load Transformer (Conditional) ---
-    print(f"\n[2] Preparing Transformer from: {model_path}")
-    transformer_load_kwargs = {"subfolder": "transformer", "torch_dtype": model_dtype, "low_cpu_mem_usage": True}
+    print(f"\n[2] Preparing Transformer from: {model_path}"); transformer_load_kwargs = {"subfolder": "transformer", "torch_dtype": model_dtype, "low_cpu_mem_usage": True}
     
-    if is_nf4: 
-        print("     Type: NF4")
-    else:
-        # Default BNB case
+    if is_nf4: print("     Type: NF4")
+    else: # Default BNB case
         print("     Type: Standard (Applying 4-bit BNB quantization)")
         if bnb_transformer_4bit_config:
             transformer_load_kwargs["quantization_config"] = bnb_transformer_4bit_config
         else:
             raise ImportError("BNB config required for transformer but unavailable.")
-    
-    print("     Loading Transformer... (May download files)")
-    transformer = HiDreamImageTransformer2DModel.from_pretrained(model_path, **transformer_load_kwargs)
-    print("     Moving Transformer to CUDA...")
-    transformer.to("cuda")
-    
-    step2_mem = torch.cuda.memory_allocated() / 1024**2 if torch.cuda.is_available() else 0
-    print(f"✅ Transformer loaded! (VRAM: {step2_mem:.2f} MB)")
-    
+    print("     Loading Transformer... (May download files)"); transformer = HiDreamImageTransformer2DModel.from_pretrained(model_path, **transformer_load_kwargs)
+    print("     Moving Transformer to CUDA..."); transformer.to("cuda")
+    step2_mem = torch.cuda.memory_allocated() / 1024**2 if torch.cuda.is_available() else 0; print(f"✅ Transformer loaded! (VRAM: {step2_mem:.2f} MB)")
     # --- 3. Load Scheduler ---
-    print(f"\n[3] Preparing Scheduler: {scheduler_name}")
-    scheduler = get_scheduler_instance(scheduler_name, shift)
-    print(f"     Using Scheduler: {scheduler_name}")
-    
+    print(f"\n[3] Preparing Scheduler: {scheduler_name}"); scheduler = get_scheduler_instance(scheduler_name, shift); print(f"     Using Scheduler: {scheduler_name}")
     # --- 4. Load Pipeline ---
-    print(f"\n[4] Loading Pipeline from: {model_path}")
-    print("     Passing pre-loaded components...")
-    pipe = HiDreamImagePipeline.from_pretrained(
-        model_path, 
-        scheduler=scheduler, 
-        tokenizer_4=tokenizer, 
-        text_encoder_4=text_encoder, 
-        transformer=None, 
-        torch_dtype=model_dtype, 
-        low_cpu_mem_usage=True
-    )
-    print("     Pipeline structure loaded.")
-    
+    print(f"\n[4] Loading Pipeline from: {model_path}"); print("     Passing pre-loaded components...")
+    pipe = HiDreamImagePipeline.from_pretrained(model_path, scheduler=scheduler, tokenizer_4=tokenizer, text_encoder_4=text_encoder, transformer=None, torch_dtype=model_dtype, low_cpu_mem_usage=True); print("     Pipeline structure loaded.")
     # --- 5. Final Setup ---
-    print("\n[5] Finalizing Pipeline...")
-    print("     Assigning transformer...")
-    pipe.transformer = transformer
+    print("\n[5] Finalizing Pipeline..."); print("     Assigning transformer..."); pipe.transformer = transformer
+    print("     Moving pipeline object to CUDA (final check)...");
+    try: pipe.to("cuda")
+    except Exception as e: print(f"     Warning: Could not move pipeline object to CUDA: {e}.")
     
-    print("     Moving pipeline object to CUDA (final check)...")
-    try: 
-        pipe.to("cuda")
-    except Exception as e: 
-        print(f"     Warning: Could not move pipeline object to CUDA: {e}.")
+    # Deciding whether to use CPU offload
+    should_use_cpu_offload = is_nf4 and not use_uncensored_llm
     
-    if is_nf4:
-        print("     Attempting CPU offload for NF4...")
+    if should_use_cpu_offload:
+        print("     Attempting CPU offload for NF4...");
         if hasattr(pipe, "enable_sequential_cpu_offload"):
-            try: 
-                pipe.enable_sequential_cpu_offload()
-                print("     ✅ CPU offload enabled.")
-            except Exception as e: 
-                print(f"     ⚠️ Failed CPU offload: {e}")
-        else: 
-            print("     ⚠️ enable_sequential_cpu_offload() not found.")
+            try: pipe.enable_sequential_cpu_offload(); print("     ✅ CPU offload enabled.")
+            except Exception as e: print(f"     ⚠️ Failed CPU offload: {e}")
+        else: print("     ⚠️ enable_sequential_cpu_offload() not found.")
+    else:
+        if is_nf4 and use_uncensored_llm:
+            print("     Skipping CPU offload for uncensored model to avoid device conflicts.")
     
-    final_mem = torch.cuda.memory_allocated() / 1024**2 if torch.cuda.is_available() else 0
-    print(f"✅ Pipeline ready! (VRAM: {final_mem:.2f} MB)")
-    
+    final_mem = torch.cuda.memory_allocated() / 1024**2 if torch.cuda.is_available() else 0; print(f"✅ Pipeline ready! (VRAM: {final_mem:.2f} MB)")
     return pipe, config
-
-# --- Resolution Parsing & Tensor Conversion ---
-# (your existing code here)
 
 # --- ComfyUI Node Definition ---
 class HiDreamSampler:
@@ -528,8 +492,10 @@ class HiDreamSampler:
         # --- Run Inference ---
         output_images = None
         try:
-            if not is_nf4_current: 
-                print(f"Ensuring pipe on: {inference_device} (Manual offload)")
+            is_nf4_uncensored = is_nf4_current and use_uncensored_llm
+            
+            if not is_nf4_current or is_nf4_uncensored: 
+                print(f"Ensuring pipe on: {inference_device}")
                 pipe.to(inference_device)
             else: 
                 print(f"Skipping pipe.to({inference_device}) (CPU offload enabled).")

--- a/hidreamsampler.py
+++ b/hidreamsampler.py
@@ -488,7 +488,7 @@ class HiDreamSampler:
             pipe.scheduler = get_scheduler_instance(original_scheduler_class, original_shift)
                 
         # --- Generation Setup ---
-         is_nf4_current = config.get("is_nf4", False)
+        is_nf4_current = config.get("is_nf4", False)
         num_inference_steps = override_steps if override_steps >= 0 else config["num_inference_steps"]
         guidance_scale = override_cfg if override_cfg >= 0.0 else config["guidance_scale"]
         pbar = comfy.utils.ProgressBar(num_inference_steps)

--- a/hidreamsampler.py
+++ b/hidreamsampler.py
@@ -371,8 +371,8 @@ class HiDreamSampler:
                 "use_uncensored_llm": ("BOOLEAN", {"default": False})
             },
             "optional": {
-                "max_length_clip_l": ("INT", {"default": 77, "min": 64, "max": 150}),
-                "max_length_openclip": ("INT", {"default": 77, "min": 64, "max": 150}),
+                "max_length_clip_l": ("INT", {"default": 77, "min": 64, "max": 218}),
+                "max_length_openclip": ("INT", {"default": 77, "min": 64, "max": 218}),
                 "max_length_t5": ("INT", {"default": 128, "min": 64, "max": 512}),
                 "max_length_llama": ("INT", {"default": 128, "min": 64, "max": 2048})
             }

--- a/hidreamsampler.py
+++ b/hidreamsampler.py
@@ -377,8 +377,10 @@ class HiDreamSampler:
     FUNCTION = "generate"
     CATEGORY = "HiDream"
     
+    # In basic node
     def generate(self, model_type, prompt, negative_prompt, width, height, seed, scheduler, 
                  override_steps, override_cfg, use_uncensored_llm=False, **kwargs):
+        print("DEBUG: Basic node generate() called")
         # Monitor initial memory usage
         if torch.cuda.is_available():
             initial_mem = torch.cuda.memory_allocated() / 1024**2
@@ -643,6 +645,7 @@ class HiDreamSamplerAdvanced:
                  override_steps, override_cfg, use_uncensored_llm=False,
                  clip_l_prompt="", openclip_prompt="", t5_prompt="", llama_prompt="",
                  max_length_clip_l=77, max_length_openclip=77, max_length_t5=128, max_length_llama=128, **kwargs):
+        print("DEBUG: Advanced node generate() called")
                      
         # Monitor initial memory usage
         if torch.cuda.is_available():

--- a/hidreamsampler.py
+++ b/hidreamsampler.py
@@ -495,9 +495,9 @@ class HiDreamSampler:
         
         # Define hardcoded sequence lengths BEFORE using them
         max_length_clip_l = 77
-        max_length_openclip = 77
-        max_length_t5 = 128
-        max_length_llama = 128
+        max_length_openclip = 150
+        max_length_t5 = 256
+        max_length_llama = 256
         
         try:
             inference_device = comfy.model_management.get_torch_device()

--- a/hidreamsampler.py
+++ b/hidreamsampler.py
@@ -358,6 +358,14 @@ class HiDreamSampler:
             "Karras Exponential"
         ]
         
+        # Encoder test mode options
+        test_mode_options = [
+            "All encoders at default (128)",
+            "Test CLIP encoders",
+            "Test T5 encoder",
+            "Test Llama encoder"
+        ]
+        
         return {
             "required": {
                 "model_type": (available_model_types, {"default": default_model}),
@@ -367,15 +375,11 @@ class HiDreamSampler:
                 "height": ("INT", {"default": 1024, "min": 512, "max": 2048, "step": 8}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
                 "scheduler": (scheduler_options, {"default": "Default for model"}),
+                "test_mode": (test_mode_options, {"default": "All encoders at default (128)"}),
+                "test_sequence_length": ("INT", {"default": 128, "min": 64, "max": 2048}),
                 "override_steps": ("INT", {"default": -1, "min": -1, "max": 100}),
                 "override_cfg": ("FLOAT", {"default": -1.0, "min": -1.0, "max": 20.0, "step": 0.1}),
                 "use_uncensored_llm": ("BOOLEAN", {"default": False})
-            },
-            "optional": {
-                "max_length_clip_l": ("INT", {"default": 77, "min": 64, "max": 150, "step": 1}),
-                "max_length_openclip": ("INT", {"default": 77, "min": 64, "max": 150, "step": 1}),
-                "max_length_t5": ("INT", {"default": 128, "min": 64, "max": 512, "step": 1}),
-                "max_length_llama": ("INT", {"default": 128, "min": 64, "max": 2048, "step": 1})
             }
         }
         
@@ -385,8 +389,7 @@ class HiDreamSampler:
     CATEGORY = "HiDream"
     
     def generate(self, model_type, prompt, negative_prompt, width, height, seed, scheduler, 
-                 override_steps, override_cfg, use_uncensored_llm=False, 
-                 max_length_clip_l=77, max_length_openclip=77, max_length_t5=128, max_length_llama=128, **kwargs):
+                 test_mode, test_sequence_length, override_steps, override_cfg, use_uncensored_llm=False, **kwargs):
         # Monitor initial memory usage
         if torch.cuda.is_available():
             initial_mem = torch.cuda.memory_allocated() / 1024**2
@@ -508,7 +511,27 @@ class HiDreamSampler:
         generator = torch.Generator(device=inference_device).manual_seed(seed)
         print(f"\n--- Starting Generation ---")
         print(f"Model: {model_type}{' (uncensored)' if use_uncensored_llm else ''}, Res: {height}x{width}, Steps: {num_inference_steps}, CFG: {guidance_scale}, Seed: {seed}")
-        print(f"Sequence length limits - CLIP-L: {max_length_clip_l}, OpenCLIP: {max_length_openclip}, T5: {max_length_t5}, Llama: {max_length_llama}")
+        
+        # Determine max_sequence_length based on test mode
+        max_sequence_length = 128  # Default
+        
+        if test_mode == "All encoders at default (128)":
+            max_sequence_length = 128
+            print(f"Using default sequence length: {max_sequence_length}")
+        elif test_mode == "Test CLIP encoders":
+            max_sequence_length = test_sequence_length
+            print(f"Testing CLIP encoders with sequence length: {max_sequence_length}")
+            # Truncate prompt to avoid T5/Llama issues
+            if len(prompt.split()) > 20:
+                original_prompt = prompt
+                prompt = " ".join(prompt.split()[:20])
+                print(f"Truncated prompt for CLIP test: {prompt}")
+        elif test_mode == "Test T5 encoder":
+            max_sequence_length = test_sequence_length
+            print(f"Testing T5 encoder with sequence length: {max_sequence_length}")
+        elif test_mode == "Test Llama encoder":
+            max_sequence_length = test_sequence_length
+            print(f"Testing Llama encoder with sequence length: {max_sequence_length}")
         
         # --- Run Inference ---
         output_images = None
@@ -521,42 +544,7 @@ class HiDreamSampler:
                 
             print("Executing pipeline inference...")
             with torch.inference_mode():
-                # Patching encode_prompt to use separate max sequence lengths for different encoders
-                original_encode_prompt = pipe.encode_prompt
-                
-                def patched_encode_prompt(*args, **kwargs):
-                    # Save original max_sequence_length if present
-                    original_max_sequence_length = kwargs.get("max_sequence_length", 128)
-                    # Call original function
-                    return original_encode_prompt(*args, **kwargs)
-                
-                # Replace the class methods that handle different encoders
-                original_get_clip_prompt_embeds = pipe._get_clip_prompt_embeds
-                original_get_clip_prompt_embeds2 = None
-                original_get_t5_prompt_embeds = pipe._get_t5_prompt_embeds
-                original_get_llama3_prompt_embeds = pipe._get_llama3_prompt_embeds
-                
-                def patched_get_clip_prompt_embeds(self, tokenizer, text_encoder, *args, **kwargs):
-                    if text_encoder == pipe.text_encoder:  # First CLIP model (CLIP-L)
-                        kwargs["max_sequence_length"] = max_length_clip_l
-                    else:  # Second CLIP model (OpenCLIP)
-                        kwargs["max_sequence_length"] = max_length_openclip
-                    return original_get_clip_prompt_embeds(self, tokenizer, text_encoder, *args, **kwargs)
-                
-                def patched_get_t5_prompt_embeds(self, *args, **kwargs):
-                    kwargs["max_sequence_length"] = max_length_t5
-                    return original_get_t5_prompt_embeds(self, *args, **kwargs)
-                
-                def patched_get_llama3_prompt_embeds(self, *args, **kwargs):
-                    kwargs["max_sequence_length"] = max_length_llama
-                    return original_get_llama3_prompt_embeds(self, *args, **kwargs)
-                
-                # Apply the patches
-                pipe._get_clip_prompt_embeds = patched_get_clip_prompt_embeds.__get__(pipe)
-                pipe._get_t5_prompt_embeds = patched_get_t5_prompt_embeds.__get__(pipe)
-                pipe._get_llama3_prompt_embeds = patched_get_llama3_prompt_embeds.__get__(pipe)
-                
-                # Execute inference with patched methods
+                # Updated inference code with negative_prompt and max_sequence_length
                 output_images = pipe(
                     prompt=prompt,
                     negative_prompt=negative_prompt.strip() if negative_prompt else None,
@@ -566,13 +554,8 @@ class HiDreamSampler:
                     num_inference_steps=num_inference_steps,
                     num_images_per_prompt=1,
                     generator=generator,
+                    max_sequence_length=max_sequence_length,
                 ).images
-                
-                # Restore original methods
-                pipe._get_clip_prompt_embeds = original_get_clip_prompt_embeds
-                pipe._get_t5_prompt_embeds = original_get_t5_prompt_embeds
-                pipe._get_llama3_prompt_embeds = original_get_llama3_prompt_embeds
-                
             print("Pipeline inference finished.")
         except Exception as e:
             print(f"!!! ERROR during execution: {e}")


### PR DESCRIPTION
## Added Many improvements! ##
- Added "use_uncensored_llm" option - this currently loads a different llama3.1-8b model that is just as censored as the first model. I will work on setting up a proper LLM replacement here, but may take a few days to get working properly. Until then this is just a "try a different LLM model" button. ** THIS IS STILL A WIP, DON'T @ ME **
- Renamed the existing node to "HiDream Sampler"
- Added new Node "HiDream Sampler (Advanced)"
- Exposed negative prompt for both (Note - only works on Full and Full-nf4 models)
- changed resolution to discrete integers to allow for free-range resolution setting instead of predefined values
-  - Modified library to remove cap on output resolution/scale. Watch out, you can OOM yourself if you go too big. Also, I haven't tested really large images yet, the results will likely be really funky.
- modified the HiDream library to accept different max lengths per encoder model, as the previous 128 limit being enforced for all 4 encoder models was ridiculously low and stupid to put in front of an LLM or t5xxl.
- - For the 'simple' sampler node, I set the defaults to:  CLIP-L: 77, OpenCLIP: 150, T5: 256, Llama: 256 
- Advanced sampler node adds discrete values for max input lengths for each encoder, as well as a prompt box for each encoder.  - - Default behavior is the primary prompt is used for all 4 encoder inputs unless overridden by an individual encoder input prompt. 
- - - you can 'blank out' any encoder you don't want to use by simply leaving the primary prompt blank, then inserting a prompt for only the encoder(s) you want to use, or use different prompts for different encoders.
- - I think there is something wonky going on with the LLM encoder, it seems to have a lot of output 'noise' even when the input prompt is zeroed out, which I suspect is the LLM hallucinating output, will investigate but until then, the LLM encoder is way stronger than all of the other encoders, even when you don't feed it a prompt.