### PR TITLE
Add uncensored model

### DIFF
--- a/hidreamsampler.py
+++ b/hidreamsampler.py
@@ -130,8 +130,8 @@ NF4_MODEL_PREFIX = "azaneko"
 ORIGINAL_LLAMA_MODEL_NAME = "nvidia/Llama-3.1-Nemotron-Nano-8B-v1" # For original/FP8
 NF4_LLAMA_MODEL_NAME = "hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4" # For NF4
 # Add alternate model paths (using the same model as NF4 since it's less censored)
-ALTERNATE_LLAMA_MODEL_NAME = "hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4" 
-ALTERNATE_NF4_LLAMA_MODEL_NAME = "hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4"
+ALTERNATE_LLAMA_MODEL_NAME = "akhbar/Meta-Llama-3.1-8B-Instruct-abliterated-GPTQ" 
+ALTERNATE_NF4_LLAMA_MODEL_NAME = "akhbar/Meta-Llama-3.1-8B-Instruct-abliterated-GPTQ"
 # --- Model Configurations ---
 # Added flags for dependency checks
 MODEL_CONFIGS = {


### PR DESCRIPTION
1. Replaced the alternate model selection with `akhbar/Meta-Llama-3.1-8B-Instruct-abliterated-GPTQ` for a proper 'uncensored' option for the LLM. That said, in testing it's not making a huge difference in terms of actual uncensored output - running in a direct x/y with locked seeds and settings (only LLM is different) and running NSFW wildcards, the amount of actual nudity provided by both models are roughly the same. that said, it does provide "different' output, so may still be worth exploring. Also, you may be able to get better results with targeted system prompts, something I haven't had time to really test.
2. Fixed a GC bug, and removed an erroneous size error from the LLM encoder flow. 


NOTE - IF you preferred the old alternate model, you can add it back in simply by editing the alternate model paths in hidreamsampler.py:

**Old alternate model:** `hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4`
**New 'uncensored' alternate model:** `akhbar/Meta-Llama-3.1-8B-Instruct-abliterated-GPTQ`